### PR TITLE
Feat/runtime handler

### DIFF
--- a/README.md
+++ b/README.md
@@ -101,9 +101,86 @@ async def hello(task):
 
 config = SmallOSConfig.from_json_file("smallos.config.json")
 runtime = SmallOS(config=config).setKernel(Unix())
+runtime.setErrorHandler(
+    lambda event: print(
+        "[smallOS] task failure in {} (PID {}): {}".format(
+            event["task_name"] or "unnamed task",
+            event["task_id"],
+            event["exception_repr"],
+        )
+    )
+)
 runtime.fork([SmallTask(2, hello, name="hello")])
 runtime.startOS()
 ```
+
+## Runtime Error Handling
+
+`smallOS` now supports a runtime-level error observer through
+`runtime.setErrorHandler(handler, include_cancelled=False)`.
+
+Use it when you want:
+- readable debug output for uncaught task failures
+- lightweight cleanup or bookkeeping at the runtime boundary
+- a single place to surface task errors without crashing the scheduler
+
+The handler is synchronous and receives a failure-event dictionary after the
+task has been finalized. Current event fields include:
+- `task_id`
+- `task_name`
+- `parent_id`
+- `exception`
+- `exception_type`
+- `exception_repr`
+- `is_cancelled`
+- `blocked_reason`
+- `waiting_signal`
+- `io_wait_mode`
+- `join_target_id`
+- `join_pending_ids`
+- `traceback_text`
+
+By default, `TaskCancelledError` does not trigger the handler. Pass
+`include_cancelled=True` if you want cancellation events too.
+
+Example:
+
+```python
+from SmallPackage.Kernel import Unix
+from SmallPackage.SmallOS import SmallOS
+
+
+def log_runtime_error(event):
+    print(
+        "[smallOS] task failure in {} (PID {}): {}".format(
+            event["task_name"] or "unnamed task",
+            event["task_id"],
+            event["exception_repr"],
+        )
+    )
+    if event["traceback_text"]:
+        print(event["traceback_text"], end="")
+
+
+runtime = SmallOS().setKernel(Unix())
+runtime.setErrorHandler(log_runtime_error)
+```
+
+### Closed or Invalid File Descriptors
+
+Closed or invalid file descriptors used in `wait_readable(...)` or
+`wait_writable(...)` no longer crash the whole scheduler through the platform
+poll/select layer.
+
+Instead:
+- the kernel validates the watched object before polling
+- the waiting task receives a normal exception such as `ValueError`
+- the runtime finalizes that task cleanly
+- your runtime error handler can log or clean up the failure gracefully
+
+If you do not install an error handler, the task still fails cleanly and the
+runtime keeps its internal state consistent, but adding `setErrorHandler(...)`
+is the recommended way to make these failures visible in applications.
 
 ## Configuration
 
@@ -196,6 +273,12 @@ The new demos live in [demos](demos):
   HTTP example built on the native cooperative client
 - [demos/mqtt_demo.py](demos/mqtt_demo.py):
   MQTT example built on the native cooperative client
+
+All of the shared demo entry points now install a default runtime error handler
+through [demos/common.py](demos/common.py). That means network failures,
+invalid I/O wait objects, and other uncaught task exceptions are reported as
+readable task-failure diagnostics instead of looking like abrupt scheduler
+crashes or silent exits.
 
 The original root demo remains available in
 [demo.py](demo.py) as a compatibility wrapper around

--- a/SmallPackage/SmallOS.py
+++ b/SmallPackage/SmallOS.py
@@ -15,7 +15,7 @@ from .awaitables import TaskInstruction
 from .SmallIO import SmallIO
 from .SmallConfig import SmallOSConfig
 from .OSlist import OSList
-from .SmallErrors import MaxProcessError, UnsupportedAwaitableError
+from .SmallErrors import MaxProcessError, TaskCancelledError, UnsupportedAwaitableError
 
 
 _MISSING = object()
@@ -63,6 +63,8 @@ class SmallOS(SmallIO):
         self.kernel = None
         self.eternalWatchers = self.config.eternal_watchers
         self.cursor = None
+        self.errorHandler = None
+        self.errorHandlerIncludeCancelled = False
 
         SmallIO.__init__(self, self.config.io_buffer_length)
         if kwargs:
@@ -144,6 +146,20 @@ class SmallOS(SmallIO):
     def setEternalWatchers(self, isEternalWatcherPresent):
         """Control whether the runtime exits once only watcher tasks remain."""
         self.eternalWatchers = isEternalWatcherPresent
+        return self
+
+    def setErrorHandler(self, handler, include_cancelled=False):
+        """
+        Install a best-effort runtime error observer for failed tasks.
+
+        ``handler`` is a synchronous callable that receives one failure-event
+        dictionary after the task has been finalized. Returning ``None`` removes
+        the current handler.
+        """
+        if handler is not None and not callable(handler):
+            raise TypeError("error handler must be callable or None.")
+        self.errorHandler = handler
+        self.errorHandlerIncludeCancelled = bool(include_cancelled)
         return self
 
     def _wake_sleeping_tasks(self):
@@ -499,6 +515,85 @@ class SmallOS(SmallIO):
             if not waiters and task._io_wait_obj in waiters_map:
                 del waiters_map[task._io_wait_obj]
 
+    def _should_dispatch_failure(self, task):
+        """Return whether ``task`` should produce a runtime failure event."""
+        exc = task.exception
+        if exc is None:
+            return False
+        if isinstance(exc, TaskCancelledError) and not self.errorHandlerIncludeCancelled:
+            return False
+        return True
+
+    def _snapshot_task_id(self, task):
+        """Return a task or PID reference as a PID integer when possible."""
+        if task is None or task == -1:
+            return None
+        if hasattr(task, "getID"):
+            return task.getID()
+        if isinstance(task, int):
+            return task
+        return None
+
+    def _format_exception_traceback(self, exc):
+        """Return a best-effort formatted traceback string for ``exc``."""
+        try:
+            import traceback
+        except ImportError:
+            return None
+
+        try:
+            return "".join(
+                traceback.format_exception(type(exc), exc, getattr(exc, "__traceback__", None))
+            )
+        except Exception:
+            try:
+                return "".join(traceback.format_exception_only(type(exc), exc))
+            except Exception:
+                return None
+
+    def _build_failure_event(self, task):
+        """Snapshot the task failure context before finalization clears wait state."""
+        exc = task.exception
+        return {
+            "task_id": task.getID(),
+            "task_name": task.name,
+            "parent_id": self._snapshot_task_id(task.parent),
+            "exception": exc,
+            "exception_type": type(exc).__name__ if exc is not None else None,
+            "exception_repr": repr(exc),
+            "is_cancelled": isinstance(exc, TaskCancelledError),
+            "blocked_reason": task._blocked_reason,
+            "waiting_signal": task._waiting_signal,
+            "io_wait_mode": task._io_wait_mode,
+            "join_target_id": self._snapshot_task_id(task._join_target),
+            "join_pending_ids": sorted(task._join_pending) if task._join_pending else [],
+            "traceback_text": self._format_exception_traceback(exc),
+        }
+
+    def _write_runtime_diagnostic(self, message):
+        """Write a best-effort runtime diagnostic without crashing the scheduler."""
+        if not message:
+            return
+        if not message.endswith("\n"):
+            message += "\n"
+        try:
+            if self.kernel and hasattr(self.kernel, "write"):
+                self.kernel.write(message)
+        except Exception:
+            return
+
+    def _dispatch_error_handler(self, event):
+        """Invoke the installed runtime error handler without surfacing its failures."""
+        if self.errorHandler is None:
+            return
+        try:
+            self.errorHandler(event)
+        except Exception as exc:
+            diagnostic = self._format_exception_traceback(exc) or repr(exc)
+            self._write_runtime_diagnostic(
+                "smallOS error handler failed: {}".format(diagnostic.rstrip("\n"))
+            )
+
     def _detach_from_parent(self, task):
         """Remove a finished child PID from its parent's child list."""
         parent = task.parent
@@ -542,10 +637,15 @@ class SmallOS(SmallIO):
 
     def _finalize_task(self, task):
         """Run the full shutdown sequence for a finished or cancelled task."""
+        failure_event = None
+        if self._should_dispatch_failure(task):
+            failure_event = self._build_failure_event(task)
         self._clear_wait_state(task)
         self._notify_waiters(task)
         self._detach_from_parent(task)
         self.tasks.delete(task.getID())
+        if failure_event is not None:
+            self._dispatch_error_handler(failure_event)
 
     def cancel_task(self, task, recursive=False):
         """Cancel a task by object or PID and optionally cancel its descendants."""

--- a/demos/common.py
+++ b/demos/common.py
@@ -2,8 +2,8 @@
 Shared demo helpers for desktop and board-specific smallOS examples.
 
 These helpers keep the individual demo files short while still showing the
-recommended public API: load a config file, choose a kernel, spawn tasks, and
-start the runtime.
+recommended public API: load a config file, choose a kernel, install an error
+handler, spawn tasks, and start the runtime.
 """
 
 import os
@@ -34,7 +34,50 @@ def load_demo_config(**overrides):
 
 def build_runtime(kernel, **config_overrides):
     """Create a ``SmallOS`` instance wired to the chosen kernel."""
-    return SmallOS(config=load_demo_config(**config_overrides)).setKernel(kernel)
+    runtime = SmallOS(config=load_demo_config(**config_overrides)).setKernel(kernel)
+    return install_demo_error_handler(runtime)
+
+
+def _format_failure_event(event):
+    """Return a readable multi-line summary for demo task failures."""
+    details = []
+    if event["parent_id"] is not None:
+        details.append("parent={}".format(event["parent_id"]))
+    if event["blocked_reason"] is not None:
+        details.append("blocked={}".format(event["blocked_reason"]))
+    if event["waiting_signal"] is not None:
+        details.append("signal={}".format(event["waiting_signal"]))
+    if event["io_wait_mode"] is not None:
+        details.append("io={}".format(event["io_wait_mode"]))
+    if event["join_target_id"] is not None:
+        details.append("join_target={}".format(event["join_target_id"]))
+    if event["join_pending_ids"]:
+        details.append("join_pending={}".format(event["join_pending_ids"]))
+
+    header = "[smallOS demo] task failure"
+    if event["task_name"]:
+        header += " in {}".format(event["task_name"])
+    if event["task_id"] is not None:
+        header += " (PID {})".format(event["task_id"])
+    header += ": {}".format(event["exception_repr"])
+
+    if details:
+        header += " [{}]".format(", ".join(details))
+
+    trace = event.get("traceback_text")
+    if trace:
+        return "{}\n{}".format(header, trace if trace.endswith("\n") else trace + "\n")
+    return header + "\n"
+
+
+def install_demo_error_handler(runtime, include_cancelled=False):
+    """Attach the shared demo error logger to ``runtime``."""
+
+    def _handler(event):
+        runtime.kernel.write(_format_failure_event(event))
+
+    runtime.setErrorHandler(_handler, include_cancelled=include_cancelled)
+    return runtime
 
 
 async def worker(task):

--- a/tests/test_runtime.py
+++ b/tests/test_runtime.py
@@ -339,6 +339,139 @@ class TestRuntime(unittest.TestCase):
 
         self.assertTrue(parent_task.result)
 
+    def test_error_handler_receives_uncaught_task_failure(self):
+        events = []
+        kernel = FakeKernel()
+        runtime = SmallOS().setKernel(kernel).setErrorHandler(events.append)
+
+        async def boom(task):
+            raise RuntimeError("boom")
+
+        root = SmallTask(2, boom, name="boom")
+        runtime.fork([root])
+        runtime.startOS()
+
+        self.assertEqual(1, len(events))
+        event = events[0]
+        self.assertEqual(root.getID(), event["task_id"])
+        self.assertEqual("boom", event["task_name"])
+        self.assertIsNone(event["parent_id"])
+        self.assertEqual("RuntimeError", event["exception_type"])
+        self.assertEqual("RuntimeError('boom')", event["exception_repr"])
+        self.assertFalse(event["is_cancelled"])
+        self.assertIsNone(event["blocked_reason"])
+        self.assertIsNone(event["waiting_signal"])
+        self.assertIsNone(event["io_wait_mode"])
+        self.assertIsNone(event["join_target_id"])
+        self.assertEqual([], event["join_pending_ids"])
+        self.assertIsInstance(event["exception"], RuntimeError)
+        self.assertIn("RuntimeError: boom", event["traceback_text"])
+
+    def test_error_handler_ignores_successful_completion(self):
+        events = []
+        kernel = FakeKernel()
+        runtime = SmallOS().setKernel(kernel).setErrorHandler(events.append)
+
+        async def worker(task):
+            await task.sleep(0.1)
+            return "ok"
+
+        root = SmallTask(2, worker, name="worker")
+        runtime.fork([root])
+        runtime.startOS()
+
+        self.assertEqual("ok", root.result)
+        self.assertEqual([], events)
+
+    def test_error_handler_ignores_cancelled_tasks_by_default(self):
+        events = []
+        kernel = FakeKernel()
+        runtime = SmallOS().setKernel(kernel).setErrorHandler(events.append)
+
+        async def signal_waiter(task):
+            await task.wait_signal(9)
+            return "unexpected"
+
+        async def killer(task, target):
+            await task.sleep(0.2)
+            target.kill()
+            return "killed"
+
+        async def parent(task):
+            waiter = task.spawn(signal_waiter, priority=3, name="signal_waiter")
+            task.spawn(killer, priority=1, name="killer", args=(waiter,))
+            await task.sleep(0.5)
+            return isinstance(waiter.exception, TaskCancelledError)
+
+        parent_task = SmallTask(2, parent, name="parent")
+        runtime.fork([parent_task])
+        runtime.startOS()
+
+        self.assertTrue(parent_task.result)
+        self.assertEqual([], events)
+
+    def test_error_handler_can_include_cancelled_tasks_with_pre_finalize_snapshot(self):
+        events = []
+        captured = {}
+        kernel = FakeKernel()
+        runtime = SmallOS().setKernel(kernel).setErrorHandler(events.append, include_cancelled=True)
+
+        async def signal_waiter(task):
+            await task.wait_signal(9)
+            return "unexpected"
+
+        async def killer(task, target):
+            await task.sleep(0.2)
+            target.kill()
+            return "killed"
+
+        async def parent(task):
+            waiter = task.spawn(signal_waiter, priority=3, name="signal_waiter")
+            captured["waiter"] = waiter
+            task.spawn(killer, priority=1, name="killer", args=(waiter,))
+            await task.sleep(0.5)
+            return "done"
+
+        parent_task = SmallTask(2, parent, name="parent")
+        runtime.fork([parent_task])
+        runtime.startOS()
+
+        waiter = captured["waiter"]
+        self.assertEqual("done", parent_task.result)
+        self.assertEqual(1, len(events))
+        event = events[0]
+        self.assertEqual(waiter.getID(), event["task_id"])
+        self.assertTrue(event["is_cancelled"])
+        self.assertEqual("TaskCancelledError", event["exception_type"])
+        self.assertEqual("signal", event["blocked_reason"])
+        self.assertEqual(9, event["waiting_signal"])
+        self.assertIsNone(event["io_wait_mode"])
+        self.assertIsNone(waiter._blocked_reason)
+        self.assertIsNone(waiter._waiting_signal)
+
+    def test_error_handler_failure_is_reported_without_crashing_runtime(self):
+        calls = []
+        kernel = FakeKernel()
+
+        def broken_handler(event):
+            calls.append(event["task_id"])
+            raise RuntimeError("handler boom")
+
+        runtime = SmallOS().setKernel(kernel).setErrorHandler(broken_handler)
+
+        async def boom(task):
+            raise ValueError("task boom")
+
+        root = SmallTask(2, boom, name="boom")
+        runtime.fork([root])
+        runtime.startOS()
+
+        self.assertEqual([root.getID()], calls)
+        self.assertIsInstance(root.exception, ValueError)
+        self.assertTrue(
+            any("smallOS error handler failed:" in message for message in kernel.output)
+        )
+
     def test_invalid_io_wait_object_resumes_waiter_with_error(self):
         closed_obj = ClosedWaitObject()
         kernel = StrictWaitKernel()
@@ -376,6 +509,27 @@ class TestRuntime(unittest.TestCase):
         self.assertIsNone(waiter_task._io_wait_mode)
         self.assertIsNone(waiter_task._blocked_reason)
         self.assertNotIn(closed_obj, runtime.ioReadWaiters)
+
+    def test_error_handler_receives_invalid_io_failure(self):
+        events = []
+        closed_obj = ClosedWaitObject()
+        kernel = StrictWaitKernel()
+        runtime = SmallOS().setKernel(kernel).setErrorHandler(events.append)
+
+        async def waiter(task, watched):
+            await task.wait_readable(watched)
+            return "unexpected"
+
+        waiter_task = SmallTask(2, waiter, name="waiter", args=(closed_obj,))
+        runtime.fork([waiter_task])
+        runtime.startOS()
+
+        self.assertEqual(1, len(events))
+        event = events[0]
+        self.assertEqual(waiter_task.getID(), event["task_id"])
+        self.assertEqual("ValueError", event["exception_type"])
+        self.assertIn("invalid file descriptor (-1)", event["exception_repr"])
+        self.assertIn("invalid file descriptor (-1)", event["traceback_text"])
 
 
 if __name__ == "__main__":

--- a/tests/test_runtime.py
+++ b/tests/test_runtime.py
@@ -88,6 +88,7 @@ class TestRuntime(unittest.TestCase):
         return runtime, kernel
 
     def test_priority_order_is_preserved_before_and_after_sleep(self):
+        """Higher-priority tasks should run first both before and after sleeping."""
         events = []
 
         async def worker(task):
@@ -107,6 +108,7 @@ class TestRuntime(unittest.TestCase):
         )
 
     def test_join_all_returns_results_in_requested_order(self):
+        """join_all should preserve the caller-specified child ordering."""
         async def child(task, value, delay):
             await task.sleep(delay)
             return value
@@ -122,6 +124,7 @@ class TestRuntime(unittest.TestCase):
         self.assertEqual(["first", "second"], parent_task.result)
 
     def test_wait_signal_and_join_resume_once(self):
+        """A signal wait followed by join should resume exactly once per event."""
         async def sender(task):
             await task.sleep(0.2)
             task.sendSignal(task.parent.pid, 7)
@@ -139,6 +142,7 @@ class TestRuntime(unittest.TestCase):
         self.assertEqual((7, "sent"), parent_task.result)
 
     def test_killing_joined_child_raises_into_waiter(self):
+        """Cancelling a joined child should raise TaskCancelledError into the waiter."""
         async def sleeper(task):
             await task.sleep(10)
             return "too late"
@@ -163,6 +167,7 @@ class TestRuntime(unittest.TestCase):
         self.assertEqual("caught-cancel", parent_task.result)
 
     def test_wait_readable_resumes_on_kernel_io_event(self):
+        """A task waiting on readability should resume when the kernel marks it ready."""
         io_obj = object()
 
         async def notifier(task, watched):
@@ -181,6 +186,7 @@ class TestRuntime(unittest.TestCase):
         self.assertTrue(waiter_task.result)
 
     def test_killing_io_waiter_clears_wait_registration(self):
+        """Cancelling an I/O waiter should remove it from the runtime waiter map."""
         io_obj = object()
 
         async def io_waiter(task, watched):
@@ -203,6 +209,7 @@ class TestRuntime(unittest.TestCase):
         self.assertTrue(parent_task.result)
 
     def test_cancelling_signal_waiter_clears_wait_metadata(self):
+        """Cancelling a signal waiter should clear its signal-specific blocked metadata."""
         async def signal_waiter(task):
             await task.wait_signal(9)
             return "unexpected"
@@ -228,6 +235,7 @@ class TestRuntime(unittest.TestCase):
         self.assertTrue(parent_task.result)
 
     def test_cancelling_join_waiter_unregisters_child(self):
+        """Cancelling a join waiter should unregister it from the joined child."""
         async def sleeper(task):
             await task.sleep(1)
             return "done"
@@ -259,6 +267,7 @@ class TestRuntime(unittest.TestCase):
         self.assertTrue(parent_task.result)
 
     def test_cancelling_join_all_waiter_unregisters_children(self):
+        """Cancelling a join_all waiter should unregister it from every joined child."""
         async def sleeper(task):
             await task.sleep(1)
             return "done"
@@ -298,6 +307,7 @@ class TestRuntime(unittest.TestCase):
         self.assertTrue(parent_task.result)
 
     def test_resuming_task_clears_previous_wait_metadata_before_next_wait(self):
+        """Resuming from one wait should clear old wait metadata before the next wait."""
         io_obj = object()
 
         async def waiter_task(task, watched):
@@ -340,6 +350,7 @@ class TestRuntime(unittest.TestCase):
         self.assertTrue(parent_task.result)
 
     def test_error_handler_receives_uncaught_task_failure(self):
+        """The runtime error handler should receive uncaught task failures once."""
         events = []
         kernel = FakeKernel()
         runtime = SmallOS().setKernel(kernel).setErrorHandler(events.append)
@@ -368,6 +379,7 @@ class TestRuntime(unittest.TestCase):
         self.assertIn("RuntimeError: boom", event["traceback_text"])
 
     def test_error_handler_ignores_successful_completion(self):
+        """Successful task completion should not trigger the runtime error handler."""
         events = []
         kernel = FakeKernel()
         runtime = SmallOS().setKernel(kernel).setErrorHandler(events.append)
@@ -384,6 +396,7 @@ class TestRuntime(unittest.TestCase):
         self.assertEqual([], events)
 
     def test_error_handler_ignores_cancelled_tasks_by_default(self):
+        """TaskCancelledError should be ignored by the handler unless explicitly included."""
         events = []
         kernel = FakeKernel()
         runtime = SmallOS().setKernel(kernel).setErrorHandler(events.append)
@@ -411,6 +424,7 @@ class TestRuntime(unittest.TestCase):
         self.assertEqual([], events)
 
     def test_error_handler_can_include_cancelled_tasks_with_pre_finalize_snapshot(self):
+        """The handler can opt into cancellations and still see pre-finalize wait context."""
         events = []
         captured = {}
         kernel = FakeKernel()
@@ -450,6 +464,7 @@ class TestRuntime(unittest.TestCase):
         self.assertIsNone(waiter._waiting_signal)
 
     def test_error_handler_failure_is_reported_without_crashing_runtime(self):
+        """Failures inside the runtime error handler should be downgraded to diagnostics."""
         calls = []
         kernel = FakeKernel()
 
@@ -473,6 +488,7 @@ class TestRuntime(unittest.TestCase):
         )
 
     def test_invalid_io_wait_object_resumes_waiter_with_error(self):
+        """An invalid I/O wait object should resume the waiter with a clean exception."""
         closed_obj = ClosedWaitObject()
         kernel = StrictWaitKernel()
         runtime = SmallOS().setKernel(kernel)
@@ -492,6 +508,7 @@ class TestRuntime(unittest.TestCase):
         self.assertNotIn(closed_obj, runtime.ioReadWaiters)
 
     def test_uncaught_invalid_io_wait_error_clears_wait_state(self):
+        """An uncaught invalid-I/O failure should still clear runtime wait bookkeeping."""
         closed_obj = ClosedWaitObject()
         kernel = StrictWaitKernel()
         runtime = SmallOS().setKernel(kernel)
@@ -511,6 +528,7 @@ class TestRuntime(unittest.TestCase):
         self.assertNotIn(closed_obj, runtime.ioReadWaiters)
 
     def test_error_handler_receives_invalid_io_failure(self):
+        """Invalid-I/O task failures should also be delivered through the error handler."""
         events = []
         closed_obj = ClosedWaitObject()
         kernel = StrictWaitKernel()


### PR DESCRIPTION
This PR adds a runtime-level error observer to `smallOS` and improves the way task failures are surfaced in demos and docs.

The main change is a new `SmallOS.setErrorHandler(handler, include_cancelled=False)` API. It lets applications observe uncaught task failures at the runtime boundary without crashing the scheduler. Failure events are snapshotted before wait-state cleanup, finalized normally, and then delivered to the handler as a structured event containing task identity, exception info, wait-state context, and best-effort traceback text. Handler failures are contained and written as diagnostics instead of destabilizing the runtime.

This also builds on the recent invalid file descriptor handling work. Closed or invalid file descriptors used in `wait_readable(...)` / `wait_writable(...)` now fail the waiting task cleanly instead of crashing the entire app through the poll/select layer, and the new runtime error handler provides a straightforward way to report those failures gracefully.

Additional updates:
- Added runtime tests covering uncaught failures, cancellation filtering, pre-finalize failure snapshots, invalid-I/O failure delivery, and error-handler self-failure behavior.
- Updated the README with runtime error handling docs and guidance around invalid/closed file descriptors.
- Updated the shared demo runtime setup so demos install a default error handler and print readable task-failure diagnostics.

Validation:
- `python3 -m unittest tests.test_runtime`
- `python3 -m unittest tests.test_kernel`
- `python3 -m unittest tests.test_protocol_clients`
- `python3 -m unittest discover -s tests`
- `python3 demos/unix_demo.py`
- `python3 demos/runtime_demo.py`